### PR TITLE
PID Updates for L1 & S1

### DIFF
--- a/src/enums/HuddlyHex.ts
+++ b/src/enums/HuddlyHex.ts
@@ -9,8 +9,9 @@ enum HuddlyHex {
   CLOWNFISH_PID = 0x31, // Huddly IQ (without mic and cnn feature)
   DWARFFISH_PID = 0x51, // Huddly ONE
   DARTFISH_PID = 0x41, // Huddly Canvas
-  L1_PID = 0x3e9, // Huddly L1/ACE
   BASE_PID = 0xba5e, // Huddly BASE
+  L1_PID = 0x4d3f64b, // Huddly L1/ACE => From onvif wsdd discovery response (decimal val: 81000011)
+  S1_PID = 0x4d3f64e, // Huddly S1/SEE => From onvif wsdd discovery response (decimal val: 81000014)
 }
 
 export default HuddlyHex;


### PR DESCRIPTION
Updating PID for L1 and introducing the S1 PID in this pull requests. These values are extracted from the **"hardware"** scope from the wsdd response. Ex for L1:
```
"scopes":[
  "onvif://www.onvif.org/name/L1","onvif://www.onvif.org/Profile/Streaming",
  "onvif://www.onvif.org/type/video_encoder",
  "onvif://www.onvif.org/type/ptz",
  "onvif://www.onvif.org/hardware/810-00011-MWHT",
  "onvif://www.onvif.org/location/ANY",
  "onvif://www.onvif.org/serial/12101A0024",
  "onvif://www.onvif.org/mac/90:E2:FC:90:13:26"
]
```
The `MWHT` suffix and the dash are omitted, and the result of the parsing becomes the actual product ID for the device. In other words:
- L1/Ace `0x4D3F64B == 81000011`
- S1/See `0x4D3F64E == 81000014`